### PR TITLE
Added small instruction clarification/fix to How to Use

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,8 +90,8 @@ $(document).ready(function() {
 
 &lt;div class="slide"&gt;
     &lt;p&gt;This slide will get be &rsquo;pinned&lsquo; to the top of the screen until all the slide animation builds are complete.&lt;/p&gt;
-    &lt;p class="animate-build"&gt;This paragraph will fade in (the default animation)&lt;/p&gt;
-    &lt;p class="animate-build" data-animation="space-in"&gt;This paragraph will fade in while its letter spacing contracts to normal.&lt;/p&gt;
+    &lt;p class="animate-build" data-build="1"&gt;This paragraph will fade in (the default animation)&lt;/p&gt;
+    &lt;p class="animate-build" data-animation="space-in" data-build="2"&gt;This paragraph will fade in while its letter spacing contracts to normal.&lt;/p&gt;
 &lt;/div&gt;
 </pre></blockquote></p>
 		<p><small>Available animations are <code>"fly-in-left"</code>, <code>"fly-in-right"</code>, <br /><code>"space-in"</code> and the default which is <code>"fade-in"</code></small></p>


### PR DESCRIPTION
[Hope I did this right, first Pull Request ever...]

Added 'data-build="1"' and 'data-build="2"' to the instructions of the
How-To-Use function. Without adding those in, none of the pinning,
fading, and space-in animations were working (Google Chrome, OSX Lion)
