### PR TITLE
Fixes broken github pages link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A jQuery plugin for making scrolling presentation decks
 
-For more info, check out [the scrolldeck project page](http://johnpolacek.github.com/scrolldeck.js/)
+For more info, check out [the scrolldeck project page](http://johnpolacek.github.io/scrolldeck.js/)
 
 [Follow me on Twitter](http://twitter.com/johnpolacek)
 


### PR DESCRIPTION
Changes github pages link to point to http://johnpolacek.github.io/scrolldeck.js/ instead of http://johnpolacek.github.com/scrolldeck.js/. As of April 15, 2021, github stopped redirecting github pages from github.com to github.io. See their blogpost discussing the details [here.][github-stop-redirecting-github-com]

Before this change, the page I land on when clicking <http://johnpolacek.github.com/scrolldeck.js/> in your [README] looks like this:

![broken-github-pages-link]

[broken-github-pages-link]: https://user-images.githubusercontent.com/3966100/132711955-56b41178-1ab6-434f-9cd0-018d536f2a01.png "Broken GitHub Pages link"
[github-stop-redirecting-github-com]: https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/ "GitHub Pages will stop redirecting Pages sites from *.github.com after April 15, 2021"
[README]: https://github.com/johnpolacek/scrolldeck.js/blob/master/README.md "johnpolacek/scrolldeck.js - Scrolldeck"

